### PR TITLE
[fixed] 添加缺失的未定义变量udf

### DIFF
--- a/jquery-drop.js
+++ b/jquery-drop.js
@@ -16,6 +16,8 @@
  * 构造
  * 2014年7月18日19:53:11
  * SPM 模块化
+ * 2015年11月10日15:27:50
+ * [fixed] 添加缺失的未定义变量udf
  *
  */
 
@@ -26,7 +28,8 @@ module.exports = function($) {
     if(!$.fn.drag) require('jquery-drag')($);
 
     // 保存实例化对象的data键
-    var datakey = 'jquery-drop',
+    var udf,
+        datakey = 'jquery-drop',
         // 默认参数
         defaults = {
             // 释放类型

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   "spm": {
     "main": "jquery-drop.js",
     "dependencies": {
-      "jquery-drag": "1.2.1"
+      "jquery-drag": "1.0.0"
     }
   }
 }


### PR DESCRIPTION
jquery-drag目前在spmjs.io的版本只有1.0.0
1、变量udf未在插件中定义
2、jquery-drag目前在spmjs.io的版本只有1.0.0
